### PR TITLE
Single command to download and compile the zen binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ ifeq ($(BSPROOT),)
 endif
 
 subdir-y := tools
-#subdir-y += zcash
+subdir-y += zen
 
-zcash_depends-y = \
+zen_depends-y = \
 	tools
 
 include Makefile.lib

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Yet Another Zencash Builder for Apple Platform
 
-![Screenshot](https://github.com/kozyilmaz/zcash-apple/raw/master/docs/zcash-apple.png "Zcash on Mac OS")
-
 **This project requires Xcode 9 and a Mac running macOS 10.12.6 or later.**  
 This repository builds standalone Zen binaries for macOS platform without installing brew.  
 All build tools (`autoconf, automake, libtool, pkgconfig, cmake, install and readlink`) and `Zen` are compiled from scratch.  
@@ -18,6 +16,11 @@ $ source environment
 $ make
 ```
 
+For those who are trying to compile on OS X Catalina, you many need to run the following if you receive any errors about missing headers
+```shell
+$ sudo ln -s /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/* /usr/local/include/
+```
+
 In case of an error please run the following command for debug info
 ```shell
 $ PRINT_DEBUG=y make all
@@ -26,26 +29,26 @@ After successful build Zen binaries will be installed to `out` directory under p
 You can then copy binary directory anywhere you like there are no dependencies to the build tree anymore  
 ```shell
 bash-3.2$ ls -lrt out/usr/local/bin
-total 32136
--rwxr-xr-x@ 1 loki  staff       483 Feb 25 21:19 zen-init
--rw-r--r--@ 1 loki  staff      1766 Feb 25 21:19 zen-commands.txt
--rwxr-xr-x@ 1 loki  staff  13369544 Feb 25 21:39 zend
--rwxr-xr-x@ 1 loki  staff   1814860 Feb 25 21:39 zen-tx
--rwxr-xr-x@ 1 loki  staff      4761 Feb 25 21:39 zen-fetch-params
--rwxr-xr-x@ 1 loki  staff   1238732 Feb 25 21:39 zen-cli
--rw-r--r--@ 1 loki  staff        54 Feb 25 21:39 version.txt
+total 42008
+-rw-r--r--  1 loki  staff   1.7K 18 Feb 13:19 zen-commands.txt
+-rwxr-xr-x  1 loki  staff   467B 18 Feb 13:19 zen-init*
+-rwxr-xr-x  1 loki  staff    17M 18 Feb 14:06 zend*
+-rwxr-xr-x  1 loki  staff   1.5M 18 Feb 14:06 zen-cli*
+-rwxr-xr-x  1 loki  staff   2.2M 18 Feb 14:06 zen-tx*
+-rwxr-xr-x  1 loki  staff   6.8K 18 Feb 14:06 zen-fetch-params*
+
 bash-3.2$ otool -L out/usr/local/bin/zend
 out/usr/local/bin/zend:
-    /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.0.0)
-    /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 400.9.0)
+	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 800.7.0)
+	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
 bash-3.2$ otool -L out/usr/local/bin/zen-cli 
 out/usr/local/bin/zen-cli:
-    /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 400.9.0)
-    /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.0.0)
+	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
+	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 800.7.0)
 bash-3.2$ otool -L out/usr/local/bin/zen-tx
 out/usr/local/bin/zen-tx:
-    /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 400.9.0)
-    /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.0.0)
+	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
+	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 800.7.0)
 ```
 
 ### Run instructions
@@ -147,7 +150,8 @@ should look like this:
 ## Thanks
 Developers of `Zcash`  
 Developers of `ZClassic` for MacOS patches
-Developers of `Zencash` 
+
+Developers of `Horizen` 
 ## Donations
 If you feel this project is useful to you. Feel free to donate.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# Yet Another Zencash Builder for Apple Platform
+
+![Screenshot](https://github.com/kozyilmaz/zcash-apple/raw/master/docs/zcash-apple.png "Zcash on Mac OS")
+
+**This project requires Xcode 9 and a Mac running macOS 10.12.6 or later.**  
+This repository builds standalone Zen binaries for macOS platform without installing brew.  
+All build tools (`autoconf, automake, libtool, pkgconfig, cmake, install and readlink`) and `Zen` are compiled from scratch.  
 
 
 ### Build instructions
@@ -15,36 +22,142 @@ In case of an error please run the following command for debug info
 ```shell
 $ PRINT_DEBUG=y make all
 ```
-Clone the ZenCash repository and fetch the necessary parameters:
-Build using the following command (with NUM_CORES = number of cores to use for the build process):
-
+After successful build Zen binaries will be installed to `out` directory under project root  
+You can then copy binary directory anywhere you like there are no dependencies to the build tree anymore  
 ```shell
-git clone https://github.com/ZencashOfficial/zencash.git
-cd zencash/
-./zcutil/fetch-params.sh
-LIBTOOLIZE=glibtoolize ./zcutil/build-mac-clang.sh --disable-libs -j(NUM_CORES)
+bash-3.2$ ls -lrt out/usr/local/bin
+total 32136
+-rwxr-xr-x@ 1 loki  staff       483 Feb 25 21:19 zen-init
+-rw-r--r--@ 1 loki  staff      1766 Feb 25 21:19 zen-commands.txt
+-rwxr-xr-x@ 1 loki  staff  13369544 Feb 25 21:39 zend
+-rwxr-xr-x@ 1 loki  staff   1814860 Feb 25 21:39 zen-tx
+-rwxr-xr-x@ 1 loki  staff      4761 Feb 25 21:39 zen-fetch-params
+-rwxr-xr-x@ 1 loki  staff   1238732 Feb 25 21:39 zen-cli
+-rw-r--r--@ 1 loki  staff        54 Feb 25 21:39 version.txt
+bash-3.2$ otool -L out/usr/local/bin/zend
+out/usr/local/bin/zend:
+    /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.0.0)
+    /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 400.9.0)
+bash-3.2$ otool -L out/usr/local/bin/zen-cli 
+out/usr/local/bin/zen-cli:
+    /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 400.9.0)
+    /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.0.0)
+bash-3.2$ otool -L out/usr/local/bin/zen-tx
+out/usr/local/bin/zen-tx:
+    /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 400.9.0)
+    /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.0.0)
 ```
 
-for example:
+### Run instructions
+
+When launching `Zen` on MacOS for the first time, certain initalization steps should be completed.  
+Please run the commands below once for the first time  
 
 ```shell
-LIBTOOLIZE=glibtoolize ./zcutil/build-mac-clang.sh --disable-libs -j4
+$ cd out/usr/local/bin
+
+# for testnet
+$ ./zen-fetch-params --testnet
+
+# for mainnet
+$ ./zen-fetch-params
+
+$ ./zen-init
+$ ./zend
 ```
-or
+
+You can just run `Zen` by launching the daemon afterwards. After blockchain is sync'd, you can use the sample commands provided in [zen-commands.txt](zen/files/zen-commands.txt)  
+
+`$ ./zend`  
+
+Console output from the first run is below:
 ```shell
-export LIBTOOLIZE=glibtoolize
- ./zcutil/build-mac-clang.sh --disable-libs -j4
- ```
- ### Build with the tools already compiled (example having all the sources in the ~/sources/ folder)
-```shell
-$ cd ~/zencash-apple
-$ source environment
-$ cd ~/zencash
-$ export LIBTOOLIZE=glibtoolize
-$ ./zcutil/build-mac-clang.sh --disable-libs -j4 
+bash-3.2$ ./zen-fetch-params
+Zen - fetch-params.sh
+
+This script will fetch the Zcash zkSNARK parameters and verify their
+integrity with sha256sum.
+
+If they already exist locally, it will exit now and do nothing else.
+The parameters are currently just under 911MB in size, so plan accordingly
+for your bandwidth constraints. If the files are already present and
+have the correct sha256sum, no networking is used.
+
+Creating params directory. For details about this directory, see:
+/Users/loki/Library/Application Support/ZcashParams/README
+
+Retrieving: https://z.cash/downloads/sprout-proving.key
+######################################################################## 100.0%
+/Users/loki/Library/Application Support/ZcashParams/sprout-proving.key.dl: OK
+/Users/loki/Library/Application Support/ZcashParams/sprout-proving.key.dl -> /Users/loki/Library/Application Support/ZcashParams/sprout-proving.key
+Retrieving: https://z.cash/downloads/sprout-verifying.key
+######################################################################## 100.0%
+/Users/loki/Library/Application Support/ZcashParams/sprout-verifying.key.dl: OK
+/Users/loki/Library/Application Support/ZcashParams/sprout-verifying.key.dl -> /Users/loki/Library/Application Support/ZcashParams/sprout-verifying.key
+bash-3.2$ 
+bash-3.2$ cat zcash-init 
+#!/bin/bash
+
+# excerpted from zclassic/zutil/init-mac.sh
+
+if [ ! -f "$HOME/Library/Application Support/Zen/zen.conf" ]; then
+    echo "Creating zen.conf"
+    mkdir -p "$HOME/Library/Application Support/Zen/"
+    echo "rpcuser=zenrpc" > ~/Library/Application\ Support/Zen/zen.conf
+    PASSWORD=$(cat /dev/urandom | env LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+    echo "rpcpassword=$PASSWORD" >> "$HOME/Library/Application Support/Zen/zen.conf"
+    echo "Complete!"
+fi
+bash-3.2$ 
+bash-3.2$ ./zen-init 
+Creating zen.conf
+Complete!
 ```
- 
- 
+
+## Running the testnetwork
+Modify your ```$HOME/Library/Application\ Support/Zen/zen.conf``` file and make sure it looks like this:
+
+``` 
+rpcuser=SOME_USERNAME
+rpcpassword=SOME_PASSWORD
+
+### connect to test network
+testnet=1
+addnode=testnet.z.cash
+```
+You can read more about configs and changing between network [here](https://github.com/ZencashOfficial/zen/blob/master/contrib/debian/examples/zen.conf) on zen's example config file.
+
+Now your config is good to go, start the network back up:
+```shell
+$ cd out/usr/local/bin
+$ ./zend
+```
+
+## See / query which network is running
+```shell
+$ cd out/usr/local/bin
+$ ./zen-cli getmininginfo
+```
+should look like this:
+``` 
+"testnet": true,
+  "chain": "test",
+```
+
+## Thanks
+Developers of `Zcash`  
+Developers of `ZClassic` for MacOS patches
+Developers of `Zencash` 
+## Donations
+If you feel this project is useful to you. Feel free to donate.
+
+    BTC address: 1GmXRm5sEATy3Kz1hCxS1dwfXuCPkevsa
+    ZEC address: t1MW8Vx4SF1ewmL3rTN8UfRxULFTaugh1ab
+
+
 ### Disclaimer
-this is a fork of https://github.com/kozyilmaz/zcash-apple.git
+This program is not officially endorsed by or associated with the Zcash project and the Zcash Company.
+[Zcash®](https://trademarks.justia.com/871/93/zcash-87193130.html) and the 
+[Zcash® logo](https://trademarks.justia.com/868/84/z-86884549.html) are trademarks of the
+[Zerocoin Electric Coin Company](https://trademarks.justia.com/owners/zerocoin-electric-coin-company-3232749/).
 

--- a/package.sh
+++ b/package.sh
@@ -27,23 +27,23 @@ else
    release_version=$git_tag_string
 fi
 
-echo "zcash-for-macos commit version : $git_rev_string"
-echo "zcash-for-macos tag version    : $git_tag_string"
-echo "creating 'zcash-macos-$release_version' release"
+echo "zen-for-macos commit version : $git_rev_string"
+echo "zen-for-macos tag version    : $git_tag_string"
+echo "creating 'zen-macos-$release_version' release"
 
 # prepare environment
 source environment;
 export BSPJOB=16;
-export BSPINSTALL=${BSPROOT}/zcash-macos-$release_version;
+export BSPINSTALL=${BSPROOT}/zen-macos-$release_version;
 
 # build tools
 make
 echo $git_rev_string  > ${BSPINSTALL}/usr/local/bin/version.txt
 echo $git_tag_string >> ${BSPINSTALL}/usr/local/bin/version.txt
-echo "Zcash for macOS ($release_version) is installed to ${BSPINSTALL}"
+echo "Zen for macOS ($release_version) is installed to ${BSPINSTALL}"
 
 # create tarball and checksum
-echo "creating Zcash tarball 'zcash-macos-$release_version.tar.bz2' and checksum"
-tar -cjvf zcash-macos-$release_version.tar.bz2 zcash-macos-$release_version
-shasum -a 256 zcash-macos-$release_version.tar.bz2 > zcash-macos-$release_version.tar.bz2.hash
-shasum -a 256 -c zcash-macos-$release_version.tar.bz2.hash
+echo "creating Zen tarball 'zen-macos-$release_version.tar.bz2' and checksum"
+tar -cjvf zen-macos-$release_version.tar.bz2 zen-macos-$release_version
+shasum -a 256 zen-macos-$release_version.tar.bz2 > zen-macos-$release_version.tar.bz2.hash
+shasum -a 256 -c zen-macos-$release_version.tar.bz2.hash

--- a/zen/Makefile
+++ b/zen/Makefile
@@ -1,0 +1,34 @@
+
+target_name ?= zen
+
+include ../Makefile.build
+
+ZEN_VERSION=v2.0.17
+
+zen_clone:
+	if [ ! -d "zen_$(ZEN_VERSION)" ]; then git clone -b $(ZEN_VERSION) https://github.com/ZencashOfficial/zen.git zen_$(ZEN_VERSION); fi
+
+zen_config:
+	@true
+
+zen_build:
+	( cd zen_$(ZEN_VERSION); \
+		CFLAGS="" CXXFLAGS="" LIBTOOLIZE=glibtoolize ./zcutil/build.sh -j ${BSPJOB}; \
+	)
+
+zen_install:
+	rm -rf tmp
+	mkdir -p tmp
+	mkdir -p ${BSPINSTALL}/usr/local
+	make DESTDIR=${BSPROOT}/zen/tmp -C zen_$(ZEN_VERSION) install
+	cp -af ${BSPROOT}/zen/tmp/* ${BSPINSTALL}
+	cp -a files/* ${BSPINSTALL}/usr/local/bin
+
+zen_uninstall:
+	make -C zen_$(ZEN_VERSION) uninstall
+
+zen_clean:
+	if [ -f "zen_$(ZEN_VERSION)/Makefile" ]; then make -C zen_$(ZEN_VERSION) distclean; fi
+
+zen_distclean:
+	rm -rf zen_$(ZEN_VERSION)

--- a/zen/Makefile
+++ b/zen/Makefile
@@ -3,7 +3,7 @@ target_name ?= zen
 
 include ../Makefile.build
 
-ZEN_VERSION=v2.0.17
+ZEN_VERSION=v2.0.20
 
 zen_clone:
 	if [ ! -d "zen_$(ZEN_VERSION)" ]; then git clone -b $(ZEN_VERSION) https://github.com/ZencashOfficial/zen.git zen_$(ZEN_VERSION); fi

--- a/zen/files/zen-commands.txt
+++ b/zen/files/zen-commands.txt
@@ -1,0 +1,59 @@
+
+# for detailed information use the guides below
+https://github.com/ZencashOfficial/zen/wiki/1.0-User-Guide
+https://github.com/ZencashOfficial/zen/blob/master/doc/payment-api.md
+https://en.bitcoin.it/wiki/Original_Bitcoin_client/API_calls_list
+
+# list info for a command 
+$ ./zen-cli help <command>
+
+
+# list all accounts (therefore all t-addr's)
+$ ./zen-cli listreceivedbyaddress 0 true
+
+# list of t-addr's for default account (again all t-addr's)
+$ ./zen-cli getaddressesbyaccount ""
+
+# list all unspent transaction outputs (t-addr UTXO's)
+$ ./zen-cli listunspent
+
+# create new t-addr's
+$ ./zen-cli getnewaddress
+
+
+
+# list all z-addr's
+$ ./zen-cli z_listaddresses
+
+# create new z-addr's
+$ ./zen-cli z_getnewaddress
+
+# get total balance
+$ ./zen-cli z_gettotalbalance
+
+
+
+# send funds
+$ export TADDR='t1TGVDzsEK2qbG1N8FJQFSAzV1bWWHMGGCS'
+$ export ZADDR='zcNeXiyD3JkhKTrU38xM9C6HQGy9aP5qqVFH25qFzQGnmdwYZ2Dr53Jy7iRp64D4CzkMZdmKagN6mmtu3jVKHuZ8xZp8fw3'
+$ export FRIEND='zcfZJW3qLHpSc7q7W1SXRGdVjgM6Q6kRwdkz1DHW5sP2EqcMHf5RCp3Frpf2qnb81j9K6upzRN4HoVxfboVwLTRaZ7bKn8b'
+
+# send from t-addr to z-addr (with memo and fee)
+$ ./zen-cli z_sendmany "$TADDR" "[{\"address\": \"$ZADDR\", \"amount\": 0.1, \"memo\": \"0123456789\"}]" 1 0.002
+
+# send from t-addr to t-addr (with fee)
+$ ./zen-cli z_sendmany "$TADDR1" "[{\"address\": \"$TADDR2\", \"amount\": 0.09}]" 1 0.002
+
+# send from z-addr to z-addr (with memo and fee)
+$ ./zen-cli z_sendmany "$ZADDR" "[{\"address\": \"$FRIEND\", \"amount\": 0.05, \"memo\": \"9876543210\"}]" 1 0.002
+
+# get send result
+$ ./zen-cli z_getoperationresult [\"$OPID\"]
+
+
+# list amounts received by z-addr
+$ ./zen-cli z_listreceivedbyaddress "$ZADDR"
+
+# list balance both for t-addr and z-addr
+$ ./zen-cli z_getbalance "$TADDR"
+

--- a/zen/files/zen-init
+++ b/zen/files/zen-init
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# excerpted from zclassic/zutil/init-mac.sh
+
+if [ ! -f "$HOME/Library/Application Support/Zen/zen.conf" ]; then
+	echo "Creating zen.conf"
+	mkdir -p "$HOME/Library/Application Support/Zen/"
+	echo "rpcuser=zcashrpc" > ~/Library/Application\ Support/Zen/zen.conf
+	PASSWORD=$(cat /dev/urandom | env LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+	echo "rpcpassword=$PASSWORD" >> "$HOME/Library/Application Support/Zen/zen.conf"
+	echo "Complete!"
+fi


### PR DESCRIPTION
This PR uses a single command to download and compile the zen binaries instead of manually downloading the git repo.

Compilation also succeeded on OS X Catalina utilising a symlink to the include headers